### PR TITLE
Fix: new lumi_fw.tar does not allow deletion

### DIFF
--- a/firmwares/modified/S1E/s1e_update.sh
+++ b/firmwares/modified/S1E/s1e_update.sh
@@ -386,8 +386,16 @@ update_prepare() {
     # coor_dir_="/data/ota-files"
     # fws_dir_="/data/ota_dir"
 
+    firmwares_="$fws_dir_/lumi_fw.tar"
+
     # Clean old firmware directory.
-    if [ -d $fws_dir_ ]; then rm $fws_dir_ -rf; fi
+    if [ -d $fws_dir_ ]; then
+        if [-f $firmwares_]; then
+            chattr -i $firmwares_
+            rm $firmwares_ -f
+        fi
+        rm $fws_dir_ -rf
+    fi
     if [ -d $coor_dir_ ]; then rm $coor_dir_ -rf; fi
     if [ -d $ota_dir_ ]; then rm $ota_dir_ -rf; fi
 
@@ -410,7 +418,6 @@ update_prepare() {
 
     dfu_pkg_="$1"
 
-    firmwares_="$fws_dir_/lumi_fw.tar"
 
     kernel_bin_="$ota_dir_/kernel"
     rootfs_bin_="$ota_dir_/rootfs.sqfs"


### PR DESCRIPTION
Ran into an issue when running custom firmeware updates:
![image](https://github.com/niceboygithub/AqaraSmartSwitchS1E/assets/5152235/09e3e51c-6031-4226-8a36-1093b28e2e01)
It seems that newly downladed lumi_fw.tar has `Cannot be modified (immutable)` property set.

Added chattr command before deleting files to resolve.